### PR TITLE
FindById & empty results

### DIFF
--- a/Simple.Data.MongoDB/BsonDocumentExtensions.cs
+++ b/Simple.Data.MongoDB/BsonDocumentExtensions.cs
@@ -1,8 +1,5 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Linq;
-using System.Text;
-
 using MongoDB.Bson;
 
 namespace Simple.Data.MongoDB
@@ -16,6 +13,8 @@ namespace Simple.Data.MongoDB
 
         public static IDictionary<string, object> ToDictionary(this BsonDocument document, IDictionary<string, string> aliases)
         {
+            if (document == null) return null;
+
             return document.Elements.ToDictionary(x => aliases.ContainsKey(x.Name) ? aliases[x.Name] : x.Name, x => ConvertValue(x.Name, x.Value, aliases), MongoIdKeyComparer.DefaultInstance);
         }
 

--- a/Simple.Data.MongoDBTest/DatabaseHelper.cs
+++ b/Simple.Data.MongoDBTest/DatabaseHelper.cs
@@ -1,11 +1,5 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-
-using MongoDB.Bson.Serialization;
+﻿using System.Collections.Generic;
 using MongoDB.Driver;
-
 using Simple.Data.MongoDB;
 
 namespace Simple.Data.MongoDBTest
@@ -23,6 +17,13 @@ namespace Simple.Data.MongoDBTest
             server.Connect();
             server.DropDatabase("simpleDataTests");
             InsertData(server.GetDatabase("simpleDataTests"));
+        }
+
+        public static void Empty()
+        {
+            var server = MongoServer.Create("mongodb://localhost/?safe=true");
+            server.Connect();
+            server.DropDatabase("simpleDataTests");
         }
 
         private static void InsertData(MongoDatabase db)

--- a/Simple.Data.MongoDBTest/EmptyFindTests.cs
+++ b/Simple.Data.MongoDBTest/EmptyFindTests.cs
@@ -1,0 +1,78 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using NUnit.Framework;
+
+namespace Simple.Data.MongoDBTest
+{
+    [TestFixture]
+    public class EmptyFindTests
+    {
+        [TestFixtureSetUp]
+        public void Setup()
+        {
+            DatabaseHelper.Empty();
+        }
+
+        [Test]
+        public void TestFindById()
+        {
+            var db = DatabaseHelper.Open();
+            var user = db.Users.FindById(1);
+            Assert.IsNull(user);
+        }
+
+        [Test]
+        public void TestFindAll()
+        {
+            var db = DatabaseHelper.Open();
+            var user = db.Users.FindAll();
+            Assert.IsNull(user);
+        }
+
+        [Test]
+        public void TestFindAllByName()
+        {
+            var db = DatabaseHelper.Open();
+            IEnumerable<User> users = db.Users.FindAllByName("Bob").Cast<User>();
+            Assert.AreEqual(0, users.Count());
+        }
+
+        [Test]
+        public void TestAnd()
+        {
+            var db = DatabaseHelper.Open();
+            IEnumerable<User> users = db.Users.FindAll(db.Users.Age > 32 && db.Users.Name == "Dave").Cast<User>();
+            Assert.AreEqual(0, users.Count());
+        }
+        
+        [Test]
+        public void TestQuery()
+        {
+            var db = DatabaseHelper.Open();
+            List<dynamic> users = db.Users.Query()
+                .Select(db.Users.Name.As("FirstName"), db.Users.Address.City.As("cty"))
+                .OrderByDescending(db.Users.Age)
+                .ThenBy(db.Users.Name)
+                .Skip(1)
+                .Take(2)
+                .ToList();
+            Assert.AreEqual(0, users.Count());
+        }
+
+        [Test]
+        public void TestRange()
+        {
+            var db = DatabaseHelper.Open();
+            IEnumerable<User> users = db.Users.FindAllByAge(32.to(48)).Cast<User>();
+            Assert.AreEqual(0, users.Count());
+        }
+
+        [Test]
+        public void TestAllCount()
+        {
+            var db = DatabaseHelper.Open();
+            var count = db.Users.All().ToList().Count;
+            Assert.AreEqual(0, count);
+        }
+    }
+}

--- a/Simple.Data.MongoDBTest/Simple.Data.MongoDBTest.csproj
+++ b/Simple.Data.MongoDBTest/Simple.Data.MongoDBTest.csproj
@@ -67,6 +67,7 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="EmptyFindTests.cs" />
     <Compile Include="DatabaseHelper.cs" />
     <Compile Include="DeleteTests.cs" />
     <Compile Include="FindTests.cs" />


### PR DESCRIPTION
Hi Craig,

I've been getting an error when calling `db.Users.FindById(x)` where x points to an id that can't be found. I was expecting it to return `null`, but instead I was seeing an exception due to the `.ToDictionary()` extension being called on a `null` document instance.

Your original test (https://github.com/craiggwilson/Simple.Data.MongoDB/blob/master/Simple.Data.MongoDBTest/FindTests.cs#L26) passes because the data can be found, but it wasn't returning `null` when the database was empty or the result couldn't be found (i.e. invalid id).

I've put a `null` check on the `.ToDictionary()` call and added a few tests to cover the expected behaviour when no data can be found (i.e. `null` for `FindById` and empty collections for `FindAllByX`).

The problem might be more than I've trivially looked into, but I hope this helps.
